### PR TITLE
Fix MODE assignment from config

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -323,8 +323,10 @@ def handle_notifications_and_snapshots(rois, prev_states, current_states, base_f
 def main():
     # Create snapshots directory
     os.makedirs("snapshots", exist_ok=True)
-    
+
     config = load_config("./config.xml")
+
+    global MODE
     MODE = config.get("mode", "debug")
     samples = config.get("samples", 60)
     conf_threshold = config.get("confidence", 0.40)


### PR DESCRIPTION
## Summary
- set `MODE` globally in `main()` so runtime mode honors `config.xml`

## Testing
- `python -m py_compile src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6879508fa964832a94c9c0effb38a91c